### PR TITLE
feat: add new API for perform check on reconciled events

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,454 +1,536 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "description": "A service that permits to handle stored Verify KO events in hot-storage and cold-storage.",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "title": "nodo-verifyko-aux",
-    "version": "0.2.0"
+  "openapi" : "3.0.1",
+  "info" : {
+    "description" : "@project.description@",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "title" : "nodo-verifyko-aux",
+    "version" : "0.2.0"
   },
-  "servers": [
-    {
-      "description": "Generated server url",
-      "url": "http://localhost"
-    }
-  ],
-  "tags": [
-    {
-      "description": "Everything about statistics on Verify KO events",
-      "name": "Statistics"
-    },
-    {
-      "description": "Everything about actions on Verify KO events",
-      "name": "Actions"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+  "servers" : [ {
+    "description" : "Generated server url",
+    "url" : "http://localhost"
+  } ],
+  "tags" : [ {
+    "description" : "Everything about statistics on Verify KO events",
+    "name" : "Statistics"
+  }, {
+    "description" : "Everything about actions on Verify KO events",
+    "name" : "Actions"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             },
-            "description": "OK.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Wrong or missing function key.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             },
-            "description": "Service unavailable.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ],
-        "summary": "Return OK if application is started",
-        "tags": [
-          "Home"
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ],
+        "summary" : "Return OK if application is started",
+        "tags" : [ "Home" ]
       },
-      "parameters": [
-        {
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "in": "header",
-          "name": "X-Request-Id",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/reconciliation": {
-      "parameters": [
-        {
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "in": "header",
-          "name": "X-Request-Id",
-          "schema": {
-            "type": "string"
-          }
+    "/reconciliation" : {
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
         }
-      ],
-      "post": {
-        "description": "**Description:**  \nThe API execute a reconciliation of Verify KO events for the passed date, aligning hot-storage with cold-storage for this day.  \n\n**API properties:**\nProperty | Value\n- | -\nInternal | Y\nExternal | N\nSynchronous | SYNC\nAuthorization | NONE\nAuthentication | NONE\nTPS | 1.0/sec\nIdempotency | N\nStateless | Y\nRead/Write Intense | Read and Write\nCacheable | N\n",
-        "operationId": "reconcileEventsByDate",
-        "parameters": [
-          {
-            "description": "The date, in yyyy-MM-dd format, on which the reconciliation will be executed.",
-            "example": "2024-01-01",
-            "in": "query",
-            "name": "date",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "The time frame according to which the blocks of elements to be reconciled are generated for each step. This avoids the large queries to storages. Defined in minutes.",
-            "example": 1440,
-            "in": "query",
-            "name": "time-frame-in-minutes",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1440
-            }
+      } ],
+      "post" : {
+        "description" : "**Description:**  \nThe API execute a reconciliation of Verify KO events for the passed date, aligning hot-storage with cold-storage for this day.  \n\n**API properties:**\nProperty | Value\n- | -\nInternal | Y\nExternal | N\nSynchronous | SYNC\nAuthorization | NONE\nAuthentication | NONE\nTPS | 1.0/sec\nIdempotency | N\nStateless | Y\nRead/Write Intense | Read and Write\nCacheable | N\n",
+        "operationId" : "reconcileEventsByDate",
+        "parameters" : [ {
+          "description" : "The date, in yyyy-MM-dd format, on which the reconciliation will be executed.",
+          "example" : "2024-01-01",
+          "in" : "query",
+          "name" : "date",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReconciliationStatus"
+        }, {
+          "description" : "The time frame according to which the blocks of elements to be reconciled are generated for each step. This avoids the large queries to storages. Defined in minutes.",
+          "example" : 30,
+          "in" : "query",
+          "name" : "time-frame-in-minutes",
+          "required" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64",
+            "default" : 1440
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ReconciliationStatus"
                 }
               }
             },
-            "description": "Reconciliation executed with success.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "Reconciliation executed with success.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             },
-            "description": "If passed date is invalid.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "If passed date is invalid.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             },
-            "description": "If an error occurred during execution.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "If an error occurred during execution.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ],
-        "summary": "Reconcile VerifyKO events in hot-storage and cold-storage",
-        "tags": [
-          "Actions"
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ],
+        "summary" : "Reconcile VerifyKO events in hot-storage and cold-storage",
+        "tags" : [ "Actions" ]
       }
     },
-    "/reports": {
-      "get": {
-        "description": "**Description:**  \nThe API execute the export of a report about Verify KO events from hot-storage stored for the passed month.  \n\n**API properties:**\nProperty | Value\n- | -\nInternal | Y\nExternal | N\nSynchronous | SYNC\nAuthorization | NONE\nAuthentication | NONE\nTPS | 1.0/sec\nIdempotency | Y\nStateless | Y\nRead/Write Intense | Read\nCacheable | Y\n",
-        "operationId": "extractReportFromHotStorageByMonth",
-        "parameters": [
-          {
-            "description": "The year on which the report extraction will be executed.",
-            "example": 2020,
-            "in": "query",
-            "name": "year",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "description": "The month on which the report extraction will be executed. within four months from today.",
-            "example": 1,
-            "in": "query",
-            "name": "month",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
+    "/reconciliation/check-event" : {
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
+        }
+      } ],
+      "post" : {
+        "description" : "**Description:**  \nThe API execute a check of Verify KO event regarding its presence in hot-storage and in cold-storage.\nAll the parameters are mandatory because, in order to execute the search of the event either in hot storage and in cold storage, they are necessary for the keys generation to be used for both storages.  \n\n**API properties:**\nProperty | Value\n- | -\nInternal | Y\nExternal | N\nSynchronous | SYNC\nAuthorization | NONE\nAuthentication | NONE\nTPS | 1.0/sec\nIdempotency | N\nStateless | Y\nRead/Write Intense | Read and Write\nCacheable | N\n",
+        "operationId" : "checkIfEventIsReconciled",
+        "parameters" : [ {
+          "description" : "The value used as partition key for searching data in both storages.",
+          "example" : "1704063600-XXXXXXXXXXX-YYYYYYYYYYY",
+          "in" : "query",
+          "name" : "partition-key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {}
+        }, {
+          "description" : "The value used as row key for searching data in both storages.",
+          "example" : "da5f8886-0781-444f-84ae-d990b72be70e",
+          "in" : "query",
+          "name" : "row-key",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "The value used as timestamp for searching data in both storages.",
+          "example" : 1704063600,
+          "in" : "query",
+          "name" : "timestamp",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ReconciliationEventStatus"
+                }
+              }
             },
-            "description": "Export extracted with success.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "Check executed with success.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             },
-            "description": "If passed date is invalid.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
-                }
-              }
-            },
-            "description": "If an error occurred during execution.",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+            "description" : "If an error occurred during execution.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ],
+        "summary" : "Check if VerifyKO event is reconciled and present in hot-storage and cold-storage",
+        "tags" : [ "Actions" ]
+      }
+    },
+    "/reports" : {
+      "get" : {
+        "description" : "**Description:**  \nThe API execute the export of a report about Verify KO events from hot-storage stored for the passed month.  \n\n**API properties:**\nProperty | Value\n- | -\nInternal | Y\nExternal | N\nSynchronous | SYNC\nAuthorization | NONE\nAuthentication | NONE\nTPS | 1.0/sec\nIdempotency | Y\nStateless | Y\nRead/Write Intense | Read\nCacheable | Y\n",
+        "operationId" : "extractReportFromHotStorageByMonth",
+        "parameters" : [ {
+          "description" : "The year on which the report extraction will be executed.",
+          "example" : 2020,
+          "in" : "query",
+          "name" : "year",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
           }
-        ],
-        "summary": "Export Verify KO report by month from Hot Storage",
-        "tags": [
-          "Statistics"
-        ]
+        }, {
+          "description" : "The month on which the report extraction will be executed. within four months from today.",
+          "example" : 1,
+          "in" : "query",
+          "name" : "month",
+          "required" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : { }
+            },
+            "description" : "Export extracted with success.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "400" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description" : "If passed date is invalid.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description" : "If an error occurred during execution.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ],
+        "summary" : "Export Verify KO report by month from Hot Storage",
+        "tags" : [ "Statistics" ]
       },
-      "parameters": [
-        {
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "in": "header",
-          "name": "X-Request-Id",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "environment": {
-            "type": "string"
+  "components" : {
+    "schemas" : {
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "environment" : {
+            "type" : "string"
           },
-          "name": {
-            "type": "string"
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           }
         }
       },
-      "ReconciledEventStatus": {
-        "type": "object",
-        "properties": {
-          "cause": {
-            "type": "string"
+      "ReconciledEventStatus" : {
+        "type" : "object",
+        "properties" : {
+          "cause" : {
+            "type" : "string"
           },
-          "eventReconciledFromOtherStorage": {
-            "type": "string"
+          "eventReconciledFromOtherStorage" : {
+            "type" : "string"
           },
-          "newEventInserted": {
-            "type": "string"
+          "newEventInserted" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ]
+          "status" : {
+            "type" : "string",
+            "enum" : [ "SUCCESS", "FAILURE" ]
           }
         }
       },
-      "ReconciliationData": {
-        "type": "object",
-        "properties": {
-          "date": {
-            "type": "string"
+      "ReconciliationData" : {
+        "type" : "object",
+        "properties" : {
+          "date" : {
+            "type" : "string"
           },
-          "fromColdToHotStorage": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ReconciledEventStatus"
+          "fromColdToHotStorage" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ReconciledEventStatus"
             }
           },
-          "fromHotToColdStorage": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ReconciledEventStatus"
+          "fromHotToColdStorage" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ReconciledEventStatus"
             }
           },
-          "usedDateForSearch": {
-            "type": "string"
+          "usedDateForSearch" : {
+            "type" : "string"
           }
         }
       },
-      "ReconciliationHotColdComparation": {
-        "type": "object",
-        "properties": {
-          "fromColdToHot": {
-            "type": "integer",
-            "format": "int32"
+      "ReconciliationEventStatus" : {
+        "type" : "object",
+        "properties" : {
+          "coldStorageEvent" : {
+            "$ref" : "#/components/schemas/ReconciliationEventStorageStatus"
           },
-          "fromHotToCold": {
-            "type": "integer",
-            "format": "int32"
+          "hotStorageEvent" : {
+            "$ref" : "#/components/schemas/ReconciliationEventStorageStatus"
+          },
+          "status" : {
+            "type" : "string"
           }
         }
       },
-      "ReconciliationStatistics": {
-        "type": "object",
-        "properties": {
-          "analyzed": {
-            "$ref": "#/components/schemas/ReconciliationHotColdComparation"
+      "ReconciliationEventStorageStatus" : {
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
-          "endedAt": {
-            "type": "string",
-            "format": "date-time"
+          "eventId" : {
+            "type" : "string"
           },
-          "failed": {
-            "$ref": "#/components/schemas/ReconciliationHotColdComparation"
-          },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "succeeded": {
-            "$ref": "#/components/schemas/ReconciliationHotColdComparation"
+          "status" : {
+            "type" : "string"
           }
         }
       },
-      "ReconciliationStatus": {
-        "type": "object",
-        "properties": {
-          "overview": {
-            "$ref": "#/components/schemas/ReconciliationData"
+      "ReconciliationHotColdComparation" : {
+        "type" : "object",
+        "properties" : {
+          "fromColdToHot" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "statistics": {
-            "$ref": "#/components/schemas/ReconciliationStatistics"
+          "fromHotToCold" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "ReconciliationStatistics" : {
+        "type" : "object",
+        "properties" : {
+          "analyzed" : {
+            "$ref" : "#/components/schemas/ReconciliationHotColdComparation"
+          },
+          "endedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "failed" : {
+            "$ref" : "#/components/schemas/ReconciliationHotColdComparation"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "succeeded" : {
+            "$ref" : "#/components/schemas/ReconciliationHotColdComparation"
+          }
+        }
+      },
+      "ReconciliationStatus" : {
+        "type" : "object",
+        "properties" : {
+          "overview" : {
+            "$ref" : "#/components/schemas/ReconciliationData"
+          },
+          "statistics" : {
+            "$ref" : "#/components/schemas/ReconciliationStatistics"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "description": "The API key to access this function app.",
-        "in": "header",
-        "name": "Ocp-Apim-Subscription-Key",
-        "type": "apiKey"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "description" : "The API key to access this function app.",
+        "in" : "header",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "type" : "apiKey"
       }
     }
   }

--- a/src/main/java/it/gov/pagopa/nodoverifykoaux/model/action/check/ReconciliationEventStatus.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykoaux/model/action/check/ReconciliationEventStatus.java
@@ -1,0 +1,20 @@
+package it.gov.pagopa.nodoverifykoaux.model.action.check;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReconciliationEventStatus implements Serializable {
+    private String status;
+    private ReconciliationEventStorageStatus hotStorageEvent;
+    private ReconciliationEventStorageStatus coldStorageEvent;
+}

--- a/src/main/java/it/gov/pagopa/nodoverifykoaux/model/action/check/ReconciliationEventStorageStatus.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykoaux/model/action/check/ReconciliationEventStorageStatus.java
@@ -1,0 +1,21 @@
+package it.gov.pagopa.nodoverifykoaux.model.action.check;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReconciliationEventStorageStatus implements Serializable {
+    private String eventId;
+    private String status;
+    private Date createdAt;
+}

--- a/src/main/java/it/gov/pagopa/nodoverifykoaux/repository/TableStorageRepository.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykoaux/repository/TableStorageRepository.java
@@ -50,6 +50,13 @@ public class TableStorageRepository {
         return StreamSupport.stream(iterator, false).findFirst().orElse(null);
     }
 
+    public ColdStorageVerifyKO findByRowKey(String rowKey) {
+        String queryWhereClause = TableQuery.generateFilterCondition("RowKey", TableQuery.QueryComparisons.EQUAL, rowKey);
+        TableQuery<ColdStorageVerifyKO> query = TableQuery.from(ColdStorageVerifyKO.class).where(queryWhereClause);
+        Spliterator<ColdStorageVerifyKO> iterator = table.execute(query).spliterator();
+        return StreamSupport.stream(iterator, false).findFirst().orElse(null);
+    }
+
     public void save(ColdStorageVerifyKO eventToBeSavedInColdStorage) throws StorageException {
         table.execute(TableOperation.insertOrReplace(eventToBeSavedInColdStorage));
     }


### PR DESCRIPTION
This PR contains a new feature made in order to provide a new tool during error tracing in production environment. This new API permits to check if a passed event (referenced by `PartitionKey`, `RowKey` and event `timestamp`) was correctly reconciled, i.e. is present either in hot and cold storages.  
This API was defined in order to be used with alerting message: the log message containing these three information can be used for this checks. 

#### List of Changes
 - Add new API for execute reconciliation checks on events

#### Motivation and Context
These changes are required in order to add a new functionality useful for troubleshooting in PROD environment if the user does not have read permission on DB. 

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
